### PR TITLE
Cleanup rtc func signatures, add parse tests

### DIFF
--- a/tests/rtc/convert.c
+++ b/tests/rtc/convert.c
@@ -230,42 +230,75 @@ void checkGetTick() {
 
 void checkRFC2822() {
 	pspTime pt;
+	u64 ticks;
 	char buffer[256];
 
 	FillPSPTime(&pt,2012,1,30,2,12,15,900);
+	sceRtcGetTick(&pt, &ticks);
 	printf("Normal:\n");
 	DumpPSPTime("",&pt);
-	sceRtcFormatRFC2822(&pt, buffer, sizeof(buffer));
+	sceRtcFormatRFC2822(buffer, &ticks, 0);
 	printf("RFC 2822: %s\n", buffer);
 
 	FillPSPTime(&pt,2010,9,20,7,12,15,500);
+	sceRtcGetTick(&pt, &ticks);
 	printf("Normal:\n");
 	DumpPSPTime("",&pt);
-	sceRtcFormatRFC2822(&pt, buffer, sizeof(buffer));
+	sceRtcFormatRFC2822(buffer, &ticks, 0);
 	printf("RFC 2822: %s\n", buffer);
 }
 
 void checkRFC3339() {
 	pspTime pt;
+	u64 ticks;
 	char buffer[256];
 
 	FillPSPTime(&pt,2012,1,30,2,12,15,900);
+	sceRtcGetTick(&pt, &ticks);
 	printf("Normal:\n");
 	DumpPSPTime("",&pt);
-	sceRtcFormatRFC3339(&pt, buffer, sizeof(buffer));
+	sceRtcFormatRFC3339(buffer, &ticks, 0);
 	printf("RFC 3339: %s\n", buffer);
 
 	FillPSPTime(&pt,2010,9,20,7,12,15,500);
+	sceRtcGetTick(&pt, &ticks);
 	printf("Normal:\n");
 	DumpPSPTime("",&pt);
-	sceRtcFormatRFC3339(&pt, buffer, sizeof(buffer));
+	sceRtcFormatRFC3339(buffer, &ticks, 0);
 	printf("RFC 3339: %s\n", buffer);
 }
 
-void checkRtcParseDateTime()
-{
-	printf("Checking sceRtcParseDateTime\n");
-	printf("UNTESTED!\n");
+void testParse(const char *title, const char *dateString) {
+	u64 ticks = 0;
+	int result = sceRtcParseDateTime(&ticks, dateString);
+
+	char buffer[256] = {0};
+	sceRtcFormatRFC3339(buffer, &ticks, 0);
+	printf("  %s: %08x: %s -> %s\n", title, result, dateString, buffer);
+}
+
+void checkRtcParseDateTime() {
+	u64 ticks;
+	char buffer[256];
+
+	printf("\nsceRtcParseDateTime:\n");
+
+	testParse("From RFC3339 (Z)", "2010-09-20T07:12:15.00Z");
+	testParse("From RFC3339 (offset)", "2010-09-20T07:12:15.00+01:00");
+	testParse("From RFC3339 (no ms)", "2010-09-20T07:12:15Z");
+	testParse("Bad RFC3339 (missing TZ)", "2010-09-20T07:12:15");
+	testParse("Space separator", "2010-09-20 07:12:15Z");
+	testParse("Human speak", "today");
+	testParse("Time only", "07:12:15");
+	testParse("Date only", "2010-09-20");
+	testParse("From RFC2822", "Mon, 30 Jan 2012 02:12:15 +0000");
+	testParse("From RFC2822 date", "Mon, 30 Jan 2012");
+	testParse("From RFC2822 full weekday", "Monday, 30 Jan 2012 02:12:15 +0000");
+	testParse("From RFC2822 no weekday", "30 Jan 2012 02:12:15 +0000");
+	testParse("From RFC2822 + spaces", "Mon,  30  Jan  2012  02:12:15  +0000");
+	testParse("Blank", "");
+	// Crashes.
+	//testParse("NULL", NULL);
 }
 
 int main(int argc, char **argv) {

--- a/tests/rtc/convert.expected
+++ b/tests/rtc/convert.expected
@@ -86,15 +86,29 @@ checkSetTick: not empty:00000000
  2012, 9, 20, 7, 12, 15, 500
 Normal:
  2012, 1, 30, 2, 12, 15, 900
-RFC 2822:  04:16:00 +0416
+RFC 2822: Mon, 30 Jan 2012 02:12:15 +0000
 Normal:
  2010, 9, 20, 7, 12, 15, 500
-RFC 2822:  14:48:07 +0416
+RFC 2822: Mon, 20 Sep 2010 07:12:15 +0000
 Normal:
  2012, 1, 30, 2, 12, 15, 900
-RFC 3339: :15.71+04:16
+RFC 3339: 2012-01-30T02:12:15.00Z
 Normal:
  2010, 9, 20, 7, 12, 15, 500
-RFC 3339: :07.29+04:16
-Checking sceRtcParseDateTime
-UNTESTED!
+RFC 3339: 2010-09-20T07:12:15.00Z
+
+sceRtcParseDateTime:
+  From RFC3339 (Z): 00000000: 2010-09-20T07:12:15.00Z -> 2010-09-20T07:12:15.00Z
+  From RFC3339 (offset): 00000000: 2010-09-20T07:12:15.00+01:00 -> 2010-09-20T06:12:15.00Z
+  From RFC3339 (no ms): 00000000: 2010-09-20T07:12:15Z -> 2010-09-20T07:12:15.00Z
+  Bad RFC3339 (missing TZ): ffffffff: 2010-09-20T07:12:15 -> 0001-01-01T00:00:00.00Z
+  Space separator: ffffffff: 2010-09-20 07:12:15Z -> 0001-01-01T00:00:00.00Z
+  Human speak: ffffffff: today -> 0001-01-01T00:00:00.00Z
+  Time only: ffffffff: 07:12:15 -> 0001-01-01T00:00:00.00Z
+  Date only: ffffffff: 2010-09-20 -> 0001-01-01T00:00:00.00Z
+  From RFC2822: 00000000: Mon, 30 Jan 2012 02:12:15 +0000 -> 2012-01-30T02:12:15.00Z
+  From RFC2822 date: ffffffff: Mon, 30 Jan 2012 -> 0001-01-01T00:00:00.00Z
+  From RFC2822 full weekday: 00000000: Monday, 30 Jan 2012 02:12:15 +0000 -> 2012-01-30T02:12:15.00Z
+  From RFC2822 no weekday: ffffffff: 30 Jan 2012 02:12:15 +0000 -> 0001-01-01T00:00:00.00Z
+  From RFC2822 + spaces: ffffffff: Mon,  30  Jan  2012  02:12:15  +0000 -> 0001-01-01T00:00:00.00Z
+  Blank: ffffffff:  -> 0001-01-01T00:00:00.00Z

--- a/tests/rtc/rtc_common.h
+++ b/tests/rtc/rtc_common.h
@@ -13,14 +13,13 @@ int sceRtcSetWin32FileTime(pspTime *date, u64 filetime);
 
 #include <inttypes.h>
 // These are not in the pspsdk
-int sceRtcSetTime64_t(pspTime* date, const uint64_t*time);
-int sceRtcGetTime64_t(const pspTime* date, uint64_t*time);
+int sceRtcSetTime64_t(pspTime *date, uint64_t time);
+int sceRtcGetTime64_t(const pspTime *date, uint64_t *time);
 
-// Pure guess
-int sceRtcFormatRFC2822(pspTime *date, const char *ptr, int bufsize);
-int sceRtcFormatRFC2822LocalTime(const char *ptr, int bufsize);
-int sceRtcFormatRFC3339(pspTime *date, const char *ptr, int bufsize);
-int sceRtcFormatRFC3339LocalTime(const char *ptr, int bufsize);
+int sceRtcFormatRFC2822(char *str, const u64 *utcTicks, int tz);
+int sceRtcFormatRFC2822LocalTime(char *str, int tz);
+int sceRtcFormatRFC3339(char *str, const u64 *utcTicks, int tz);
+int sceRtcFormatRFC3339LocalTime(char *str, int tz);
 
 static void DumpPSPTime(const char* name, const pspTime* pt)
 {


### PR DESCRIPTION
This makes the formatting tests not spit out garbage.

-[Unknown]
